### PR TITLE
Guard small inputs in edges app

### DIFF
--- a/src/apps/EdgesWeigthedDelaunay3D.cpp
+++ b/src/apps/EdgesWeigthedDelaunay3D.cpp
@@ -16,6 +16,10 @@ int main(int argc, char** argv) {
     std::vector<Vertex> P;
     ParseStats st;
     if (!load_xyzw(in, P, &st)) { std::cerr << "Failed to read " << in << "\n"; return 2; }
+    if (P.size() < 4) {
+        std::cerr << "Need at least 4 valid points, got " << P.size() << "\n";
+        return 4;
+    }
     RegularTriangulation rt = regular_triangulation_cpu_bowyer(P, 0);
     if (rt.tets.empty()) rt = regular_triangulation_cpu_bruteforce(P, 0);
     EdgeList E = edges_from_triangulation(rt);


### PR DESCRIPTION
## Summary
- validate that EdgesWeigthedDelaunay3D receives at least four valid points before running the triangulation

## Testing
- `cmake -S . -B build -DWD3D_ENABLE_CUDA=ON`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `./build/EdgesWeigthedDelaunay3D sample_data/tetra5.xyzw output.edges`


------
https://chatgpt.com/codex/tasks/task_b_68aeb2155fd48326bd71fa838e8804df